### PR TITLE
adding code of conduct to pages folder

### DIFF
--- a/_posts/codeofconduct.markdown
+++ b/_posts/codeofconduct.markdown
@@ -1,0 +1,51 @@
+Arlington Ruby is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
+
+This code of conduct applies to all Arlington Ruby spaces, including our mailing lists and IRC channel, our meet ups and the Retrocession, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the the event organizers or online moderators.
+
+Some Arlington Ruby spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
+Harassment includes:
+<ul>
+<li>Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion</li>
+<li>Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment</li>
+<li>Deliberate misgendering or use of ‘dead’ or rejected names</li>
+<li>Gratuitous or off-topic sexual images or behaviour  in spaces where they’re not appropriate</li>
+<li>Physical contact and simulated physical contact (eg, textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop.</li>
+<li>Threats of violence</li>
+<li>Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm</li>
+<li>Deliberate intimidation</li>
+<li>Stalking or following</li>
+<li>Harassing photography or recording, including logging online activity for harassment purposes</li>
+<li>Sustained disruption of discussion</li>
+<li>Unwelcome sexual attention</li>
+<li>Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others</li>
+<li>Continued one-on-one communication after requests to cease</li>
+<li>Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect vulnerable people from intentional abuse</li>
+<li>Publication of non-harassing private communication</li>
+</ul>
+
+Arlington Ruby prioritizes marginalized people’s safety over privileged people’s comfort. Arlington Ruby organizers will not act on complaints regarding:
+<ul>
+<li>‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’</li>
+<li>Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”</li>
+<li>Communicating in a ‘tone’ you don’t find congenial</li>
+<li>Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions</li>
+</ul>
+
+
+_Reporting_
+
+If you are being harassed by a member of Arlington Ruby, notice that someone else is being harassed, or have any other concerns, please contact the Arlington Ruby organizers at [email address or other contact point]. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+
+This code of conduct applies to Arlington Ruby spaces, but if you are being harassed by a member of Arlington Ruby outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Arlington Ruby members, especially Arlington Ruby organizers, seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The organizers reserve the right to exclude people from Arlington Ruby based on their past behavior, including behavior outside Arlington Ruby spaces and behavior towards people who are not in Arlington Ruby.
+
+In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.
+
+We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Arlington Ruby members or the general public. We will not name harassment victims without their affirmative consent.
+
+_Consequences_
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+If a participant engages in harassing behavior, Arlington Ruby organizers may take any action they deem appropriate, up to and including expulsion from all Arlington Ruby spaces and identification of the participant as a harasser to other Arlington Ruby members or the general public.
+
+
+This Code of Conduct is based on the example policy from the Geek Feminism wiki, created by the Geek Feminism community. 


### PR DESCRIPTION
An email or another form of contact needs to be added into this still. Let me know which email/s you would like included and I can put it in. Let me know if there are any other changes you would like. This is based off of a sample provided on geekfeminism's wikia.
