### PR TITLE
remove schedule and info links now that event has passed on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,5 +9,4 @@ title: "RetroRuby: Arlington's Semi-Annual Ruby Unconference"
   <h2>Join us in Arlington on September 30th, 2017,</h2>
   <h2>from 9AM until 6PM.</h2>
   <h2>Coffee, lunch, and t-shirt included!</h2>
-  <br>
 </div>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,4 @@ title: "RetroRuby: Arlington's Semi-Annual Ruby Unconference"
   <h2>from 9AM until 6PM.</h2>
   <h2>Coffee, lunch, and t-shirt included!</h2>
   <br>
-  <h2><a href="/schedule.html">Schedule</a></h2>
-  <h2><a href="https://ti.to/codeforgood/fallretro2017">Register soon to reserve your spot!</a></h2>
 </div>


### PR DESCRIPTION
removed two links - 
- schedule link
- register link

For arlington ruby hactoberfestnight